### PR TITLE
Sequelize  syntax breaking changes after V5

### DIFF
--- a/app/dao/TemplateDao.js
+++ b/app/dao/TemplateDao.js
@@ -70,10 +70,14 @@ TemplateDao.getTemplateList = async (templateName, parentsName) => {
 	return await tProfileTemplate.findAll({
 		where: {
 			template_name: {
-				$like: '%' + templateName + '%'
+				//$like: '%' + templateName + '%'
+				//syntax breaking changes after V5, should be:
+				[Sequelize.Op.like]: '%' + templateName + '%'
 			},
 			parents_name: {
-				$like: '%' + parentsName + '%'
+				//$like: '%' + parentsName + '%'
+				//syntax breaking changes after V5, should be:
+				[Sequelize.Op.like]: '%' + parentsName + '%'
 			}
 		}
 	});


### PR DESCRIPTION
Secure Operators
With v4 you started to get a deprecation warning String based operators are now deprecated. Also concept of operators was introduced. These operators are Symbols which prevent hash injection attacks.
http://docs.sequelizejs.com/manual/querying.html#operators

by Tars-C++ WeChatGroup 欧流全 and mq30