### PR TITLE
fix bug: Interface Debugger debugs error

### DIFF
--- a/app/service/infTest/TarsClient.js
+++ b/app/service/infTest/TarsClient.js
@@ -29,7 +29,7 @@ const TarsClient = function (context, interface, objName, setName) {
 	this._context = context;
 	this._interface = interface;
 	this._name = objName;
-	this._worker = Tars._createObjectProxy(objName, setName ? setName : '');
+	this._worker = Tars._createObjectProxy(objName, setName ? setName : '', {});
 	this.writeParams = [];
 	this.readParams = [];
 }


### PR DESCRIPTION
Fix the problem that the Interface Debugger cannot use with error "Server internal error".

Fixes #31 
closes #31