### PR TITLE
fix admin role auth bug

### DIFF
--- a/app/dao/ServerDao.js
+++ b/app/dao/ServerDao.js
@@ -90,29 +90,24 @@ ServerDao.getServerConfByTemplate = async (templateName) => {
 };
 
 ServerDao.getServerConf4Tree = async (applicationList, serverNameList, allAttr) => {
-	let or = {};
-	if (!!applicationList && applicationList > 0) {
-		or['application'] = applicationList;
+	let or = [];
+	if (Array.isArray(applicationList) && applicationList.length) {
+		or.push({application: applicationList});
 	}
-	if (!!serverNameList && serverNameList.length > 0) {
-		or.push(Sequelize.where(Sequelize.fn('concat', Sequelize.col('application'), '.', Sequelize.col('server_name')), {in: serverNameList}));
+	if (Array.isArray(serverNameList) && serverNameList.length) {
+		or.push(Sequelize.where(Sequelize.fn('concat', Sequelize.col('application'), '.', Sequelize.col('server_name')), {[Op.in]: serverNameList}));
 	}
-	// if (!applicationList && !serverNameList) {
-	// 	where = {};
-	// }
-	let where = {[Op.or]: or};
 
 	let option = {};
+	if (or.length) {
+ 		option.where = {[Op.or]: or};
+	}
 
-	option.where = where;
-
-	if (allAttr) {
-	} else {
+	if (!allAttr) {
 		option.attributes = [[Sequelize.literal('distinct `application`'), 'application'],
 			'server_name', 'enable_set', 'set_name', 'set_area', 'set_group'
 		]
 	}
-
 	return await tServerConf.findAll(option);
 };
 


### PR DESCRIPTION
1. 目前版本admin角色看不到所有应用，因为对admin角色getServerConf4Tree生成的SQL如下，返回空结果
```sql
SELECT distinct `application` AS `application`, `server_name`, `enable_set`, `set_name`, `set_area`, `set_group` FROM `t_server_conf` AS `t_server_conf` WHERE 0 = 1;
```
2. 修复serverNameList的in子句

3. 修改了[数组检查方式](https://stackoverflow.com/a/24403771/86756)