### PR TITLE
Solve the garbled problem of UTF-8 Chinese characters

### DIFF
--- a/app/service/logview/LogviewService.js
+++ b/app/service/logview/LogviewService.js
@@ -66,7 +66,7 @@ LogviewService.getQueryParam = function(paramStr) {
     } else {
         cmd += "|head -" + showLine;
     }
-	cmd += " | cat -v "
+	cmd += " | cat  "
     console.log("=============>getQueryParam cmd:" + cmd);
     return cmd;
 }


### PR DESCRIPTION
When viewing the log, the characters in UTF-8 will be garbled