### PR TITLE
/api/upload_patch_package 发布包接口按照协议返回发布包ID等信息

### DIFF
--- a/app/controller/patch/PatchController.js
+++ b/app/controller/patch/PatchController.js
@@ -169,7 +169,8 @@ PatchController.uploadPatchPackage = async (ctx) => {
 			await PatchService.setPatchPackageDefault(package);
 
 			// ctx.body = "upload succ and set this package to default package!\r\n";
-			ctx.makeResObj(200, '', "upload succ and set this package to default package!");
+			//ctx.makeResObj(200, '', "upload succ and set this package to default package!");
+			ctx.makeResObj(200, '', data);
 		}
 	} catch (e) {
 		logger.error('[PatchController.uploadPatchPackage]:', e, ctx);


### PR DESCRIPTION
背景是用Jenkins上传服务打包文件  然后调用/api/upload_patch_package  根据返回发布包ID  调用add_task发布服务。


https://github.com/TarsCloud/TarsWeb/blob/528ddaf8aae56acf8e9ac49598760cb2b648bb35/docs/api.md

server/api/upload_patch_package
上传发布包

参数
application // 应用
module_name // 模块名
comment     // 备注
suse        // 发布包上传组件名称
task_id     // 任务ID（可用时间戳）
md5         // 发布包的md5值（不填则不校验）

返回值
{
    "id": 0,        // 发布包ID
    "server": "",   // 服务，应用+模块名
    "tgz": "",      // 发布包名称
    "comment": "",  // 备注
    "posttime": ""  // 更新时间
}