### PR TITLE
ret[0]为0时，平均耗时/异常率/超时率不出图的bug

### DIFF
--- a/app/service/monitor/MonitorStatService.js
+++ b/app/service/monitor/MonitorStatService.js
@@ -223,14 +223,14 @@ function mergeKey(params, theData, preData) {
 
 function translate(data) {
 	if (!data) {
-		return [-1, -1, -1, -1];
+		return [0, 0, 0, 0];
 	}
 	let ret = [];
 	let total = parseInt(data[0]) + parseInt(data[1]) + parseInt(data[2]);
 	ret[0] = total;
-	ret[1] = total == 0 ? -1 : data[3] / ret[0];
-	ret[2] = total == 0 ? -1 : data[2] / ret[0];
-	ret[3] = total == 0 ? -1 : data[1] / ret[0];
+	ret[1] = total == 0 ? 0 : data[3] / ret[0];
+	ret[2] = total == 0 ? 0 : data[2] / ret[0];
+	ret[3] = total == 0 ? 0 : data[1] / ret[0];
 	return ret;
 }
 


### PR DESCRIPTION
因为ret[0]是0时，分母为0，最后会把ret[0]-ret[3]填充为’--‘，导致echarts展示异常。
两种改法：
1、此次提交方法
2、将’--‘改为0，但是考虑到平均耗时等数据可能没有取到，所以使用方法1更为恰当