### PR TITLE
localStorage -> sessionStorage

### DIFF
--- a/client/src/pages/server/index.vue
+++ b/client/src/pages/server/index.vue
@@ -363,16 +363,16 @@ export default {
 
     getSetLocalStorage(key) {
       let result = ''
-      if(window.localStorage){
-        result = JSON.parse(JSON.parse(localStorage.getItem(key)))
+      if(window.sessionStorage){
+        result = JSON.parse(JSON.parse(sessionStorage.getItem(key)))
       }
       return result
     },
 
     setSetLocalStorage(key, val) {
       let result = ''
-      if(window.localStorage){
-        result = localStorage.setItem(key, JSON.stringify(val))
+      if(window.sessionStorage){
+        result = sessionStorage.setItem(key, JSON.stringify(val))
       }
       return result
     },


### PR DESCRIPTION
如果是localStorage的话，会存在一个问题：
浏览器开了多个tab标签，那他们就共享了这一块儿localStorage，所以如果第1个标签开了两个BTab，第2个标签也打开了同样的两个BTab和另外的1个BTab，此时激活这个BTab，切回第1个浏览器标签儿的时候，服务会串，成了第2个浏览器标签激活的BTab的服务。

所以为了避免这个bug，应该使用sessionStorage，保存的就是当前页的数据，同样生命周期也在关闭浏览器标签页的时候结束了，当开启新的浏览器标签页的时候，BTabs是空白的