### PR TITLE
fix error: "key.split is not a function"

### DIFF
--- a/app/service/monitor/MonitorPropertyService.js
+++ b/app/service/monitor/MonitorPropertyService.js
@@ -185,7 +185,7 @@ function mergeKey(params, theData, preData) {
 	let preKeys = preData.keys()
 	for (let preKey of preKeys) {
 		let key = preKey.split(',');
-		key = key.split(',');
+		//key = key.split(',');
 		if (key.length > 1 && (!params.group_by_first || params.group_by_first == 'f_date')) {
 			key[0] = params.thedate;
 		}


### PR DESCRIPTION
fix error: key.split is not a function