### PR TITLE
fix: query server nodes with set

### DIFF
--- a/app/dao/ServerDao.js
+++ b/app/dao/ServerDao.js
@@ -97,6 +97,7 @@ ServerDao.getServerConf = async (params) => {
 	params.nodeName != undefined && (where.node_name = params.nodeName);
 	if (params.enableSet) {
 		if (params.enableSet == 'Y') {
+			where.enable_set = 'Y';
 			params.setName && (where.set_name = params.setName);
 			params.setArea && (where.set_area = params.setArea);
 			params.setGroup && (where.set_group = params.setGroup);


### PR DESCRIPTION
查询带set的服务时，会将enable_set='N'，但是set_name/area/group能对应上的节点返回。
修复这个问题