### PR TITLE
feature-接口测试的返回值json格式化&解决node节点设置标签报错的问题和标签展示问题

### DIFF
--- a/app/service/resource/ResourceService.js
+++ b/app/service/resource/ResourceService.js
@@ -40,7 +40,7 @@ ResourceService.addNodeLabel = async (nodeName, name, value) => {
 		return [];
 	}
 
-	if (node.label == '') {
+	if (typeof node.label === 'undefined' || !node.label || node.label == '') {
 		node.label = '{}';
 	}
 
@@ -60,7 +60,7 @@ ResourceService.loadNodeLabel = async (nodeName) => {
 		return {};
 	}
 
-	return node.label;
+	return JSON.parse(node.label);
 }
 
 ResourceService.deleteNodeLabel = async (nodeName, name) => {

--- a/client/src/pages/server/interface-debuger.vue
+++ b/client/src/pages/server/interface-debuger.vue
@@ -343,7 +343,7 @@ export default {
                 objName : this.objName
             }).then(data => {
                 loading.hide();
-                this.outParam = data;
+                this.outParam = JSON.stringify(JSON.parse(data), null, 4);
             }).catch((err) => {
                 loading.hide();
                 this.$tip.error(`${this.$t('common.error')}: ${err.message || err.err_msg}`);


### PR DESCRIPTION
接口测试中的返回结构体json格式化，方便在返回复杂结构体的时候的时候展示
![image](https://user-images.githubusercontent.com/89832440/131771703-802ee754-c4f3-48e2-9db3-a984fab70535.png)
