### PR TITLE
解决set下的服务tab展示不完全的问题

### DIFF
--- a/client/src/pages/server/index.vue
+++ b/client/src/pages/server/index.vue
@@ -162,15 +162,11 @@ export default {
       if(!v){
         return id;
       }
-      if(v.length == 1) {
-        const app = id && id.split('.')[0].substring(1)
-        return `${app}`
-      }
-      if(v.length > 1) {
-        const app = id && id.split('.')[0].substring(1)
-        const server = id && id.split('.')[1].substring(1)
-        return `${app}.${server}`
-      }      
+      var temp_array = [];
+      v.forEach((item) => {
+        temp_array.push(item.substring(1))
+      });
+      return temp_array.join("."); 
     },
     getName(val) {
       let result = ''


### PR DESCRIPTION
原来的逻辑中，如果启用了set，那么可能会在同一个Application中有多个同名的服务（分属于不同的set），而tab展示的时候，只展示了Application和ServerName，导致无法区分；
修改之后的逻辑更加灵活，可以展示服务更完整的名字
![image](https://user-images.githubusercontent.com/89832440/134636109-f319449c-2287-4b05-ae4e-7c6005d6b59b.png)
