### PR TITLE
bugfix-解决tab名展示不完全的问题

### DIFF
--- a/client/src/pages/server/index.vue
+++ b/client/src/pages/server/index.vue
@@ -173,15 +173,12 @@
         if(!v){
           return id;
         }
-        if(v.length == 1) {
-          const app = id && id.split('.')[0].substring(1)
-          return `${app}`
-        }
-        if(v.length > 1) {
-          const app = id && id.split('.')[0].substring(1)
-          const server = id && id.split('.')[id.split('.').length-1].substring(1)
-          return `${app}.${server}`
-        }
+
+        let temp_array = [];
+        v.forEach((item) => {
+          temp_array.push(item.substring(1))
+        });
+        return temp_array.join(".");
       },
       getName(val) {
         let result = ''


### PR DESCRIPTION
开启set的情况下，原有的逻辑不能展示完整的服务路径，如下所示：
![企业微信截图_16324768187486](https://user-images.githubusercontent.com/89832440/134655582-c293cb1e-1211-4b3b-8bd1-9a1a1f47daa3.png)
在同一个Application下，如果启动set，可能会存在多个set下有相同服务名的情况，这种情况下，需要展示完整的路径：
![企业微信截图_16324769625577](https://user-images.githubusercontent.com/89832440/134655710-d9a59efb-1e15-4c7a-8ac0-38b0c33d7e17.png)
