### PR TITLE
Fix "Sign in failed:Incorrect password" error when logging in

### DIFF
--- a/sso/db-service/login/LoginService.js
+++ b/sso/db-service/login/LoginService.js
@@ -31,7 +31,7 @@ LoginServer.login = async(uid, password)=> {
     } else {
         let userInfo = await LoginDao.getUserInfoByUid(uid);
         if (userInfo) {
-            if (userInfo.password !== sha1(password)) {
+            if (userInfo.password !== sha1(sha1(password))) {
                 return {errMsg: '#login.passwordNoCorrect#'};
             } 
         } else {


### PR DESCRIPTION
Fix "Sign in failed:Incorrect password" error when logging in
修复登录时提示"登录失败:密码错误"