### PR TITLE
use the right key to get default value on interface testing

### DIFF
--- a/app/service/infTest/TarsParser/Tokenizer.js
+++ b/app/service/infTest/TarsParser/Tokenizer.js
@@ -21,6 +21,8 @@ const DELIM = /[\s\{\}=;\[\],\(\)<>]/g;
 
 class Tokenizer  {
     constructor(content, length, index) {
+        // 针对 //\n 的字符进行处理，转成 // \n，否则会导致解析报错
+        content = content.replace(/\/\/\n/g,"// \n");
         // 去掉单行和多行注释
         this.content = content.replace(/\/\/.+/g,'').replace(/\n/g,' ').replace(/(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg,'');
         this.length = length || content.length;

--- a/app/service/infTest/TarsStruct.js
+++ b/app/service/infTest/TarsStruct.js
@@ -89,7 +89,7 @@ TarsStruct.getWrappedValue = function (context, type, json) {
 	}
 };
 TarsStruct.prototype._getDefault = function (field) {
-	var defvalue = field.defvalue;
+	var defvalue = field.defaultValue;
 	if (defvalue == null) {
 		if (field.type === "bool") {
 			defvalue = DEFAULT_BOOL;
@@ -114,7 +114,7 @@ TarsStruct.prototype.resetDefault = function () {
 	var field, defvalue;
 	for (var fieldName in this._struct.fields) {
 		if ((field = this._struct.fields[fieldName])) {
-			defvalue = field.defvalue;
+			defvalue = field.defaultValue;
 			if (defvalue == null) {
 				defvalue = this._getDefault(field);
 				if (typeof (defvalue.new) === "function") {
@@ -129,7 +129,7 @@ TarsStruct.prototype._readFrom = function (is) {
 	var field, defvalue, method;
 	for (var fieldName in this._struct.fields) {
 		if ((field = this._struct.fields[fieldName])) {
-			defvalue = field.defvalue;
+			defvalue = field.defaultValue;
 			if (defvalue == null) {
 				defvalue = this._getDefault(field);
 			}

--- a/k8s/service/infTest/TarsParser/Tokenizer.js
+++ b/k8s/service/infTest/TarsParser/Tokenizer.js
@@ -21,6 +21,8 @@ const DELIM = /[\s\{\}=;\[\],\(\)<>]/g;
 
 class Tokenizer  {
     constructor(content, length, index) {
+        // 针对 //\n 的字符进行处理，转成 // \n，否则会导致解析报错
+        content = content.replace(/\/\/\n/g,"// \n");
         // 去掉单行和多行注释
         this.content = content.replace(/\/\/.+/g,'').replace(/\n/g,' ').replace(/(\/\*([\s\S]*?)\*\/|([^:]|^)\/\/(.*)$)/mg,'');
         this.length = length || content.length;

--- a/k8s/service/infTest/TarsStruct.js
+++ b/k8s/service/infTest/TarsStruct.js
@@ -89,7 +89,7 @@ TarsStruct.getWrappedValue = function (context, type, json) {
 	}
 };
 TarsStruct.prototype._getDefault = function (field) {
-	var defvalue = field.defvalue;
+	var defvalue = field.defaultValue;
 	if (defvalue == null) {
 		if (field.type === "bool") {
 			defvalue = DEFAULT_BOOL;
@@ -114,7 +114,7 @@ TarsStruct.prototype.resetDefault = function () {
 	var field, defvalue;
 	for (var fieldName in this._struct.fields) {
 		if ((field = this._struct.fields[fieldName])) {
-			defvalue = field.defvalue;
+			defvalue = field.defaultValue;
 			if (defvalue == null) {
 				defvalue = this._getDefault(field);
 				if (typeof (defvalue.new) === "function") {
@@ -129,7 +129,7 @@ TarsStruct.prototype._readFrom = function (is) {
 	var field, defvalue, method;
 	for (var fieldName in this._struct.fields) {
 		if ((field = this._struct.fields[fieldName])) {
-			defvalue = field.defvalue;
+			defvalue = field.defaultValue;
 			if (defvalue == null) {
 				defvalue = this._getDefault(field);
 			}


### PR DESCRIPTION
1、在取结构体的默认值时，使用的key是不存在的，恒为null，从而导致用户自己定义的默认值无效
![企业微信截图_16375821305640](https://user-images.githubusercontent.com/89832440/142962805-7482007d-ed7b-4a82-a902-1301caac5d97.png)
代码中默认值定义的key是`defaultValue`
![image](https://user-images.githubusercontent.com/89832440/142962861-01ff1c16-8536-4b48-bda3-caf032f67209.png)
但是使用的时候用的是`defvalue`
![image](https://user-images.githubusercontent.com/89832440/142963049-278685e1-2adf-4e07-b2f6-de8327941247.png)

2、当tars结构体字段后面有一个单行注释+空格时，会导致解析失败，如下图：
![image](https://user-images.githubusercontent.com/89832440/142970956-1f426186-f97c-435f-8768-e05e2ed01547.png)
在`Tokenizer`类的构造函数中，加入了针对此种情况的过滤



