### PR TITLE
Feature interface testcase management

### DIFF
--- a/app/controller/infTest/InfTestController.js
+++ b/app/controller/infTest/InfTestController.js
@@ -331,4 +331,101 @@ InfTestController.isBenchmarkInstalled = async (ctx) =>{
 }
 
 
+const testCaseConfStruct = {
+	case_id: '',
+	f_id: '',
+	test_case_name: '',
+	application: '',
+	server_name: '',
+	object_name: '',
+	file_name: '',
+	module_name: '',
+	interface_name: '',
+	function_name: '',
+	posttime: { formatter: util.formatTimeStamp },
+	context: "",
+	modify_user: ""
+};
+
+
+InfTestController.getTestCaseList = async (ctx) => {
+	let curPage = parseInt(ctx.paramsObj.curr_page) || 0;
+	let pageSize = parseInt(ctx.paramsObj.page_size) || 0;
+	const { f_id, objName, application, server_name, module_name, interface_name, function_name } = ctx.paramsObj;
+	try {
+
+		if (!await AuthService.hasDevAuth(application, server_name, ctx.uid)) {
+			ctx.makeNotAuthResObj();
+		} else {
+			let rst = null;
+			// 精准匹配
+			if (module_name && interface_name && function_name) {
+				rst = await InfTestService.getTestCaseList({
+					f_id: f_id, module_name: module_name,
+					interface_name: interface_name,
+					function_name: function_name
+				}, curPage, pageSize);
+			}
+			else {
+				rst = await InfTestService.getTestCaseList({ f_id: f_id }, curPage, pageSize);
+			}
+			ctx.makeResObj(200, '', { count: rst.count, rows: util.viewFilter(rst.rows, testCaseConfStruct) });
+		}
+
+	} catch (e) {
+		logger.error('[getTestCaseList]', e, ctx);
+		ctx.makeErrResObj();
+	}
+}
+
+InfTestController.interfaceAddCase = async (ctx) => {
+	try {
+		const { f_id, test_case_name, objName, file_name, application, server_name, module_name, interface_name, function_name, params } = ctx.paramsObj;
+		if (!await AuthService.hasDevAuth(application, server_name, ctx.uid)) {
+			ctx.makeNotAuthResObj();
+		} else {
+			let ret = await InfTestService.addTestCase({
+				f_id: f_id,
+				test_case_name: test_case_name,
+				application: application,
+				server_name: server_name,
+				object_name: objName,
+				file_name: file_name,
+				module_name: module_name,
+				interface_name: interface_name,
+				function_name: function_name,
+				context: params,
+				posttime: new Date(),
+				modify_user: ctx.uid
+			});
+			ctx.makeResObj(200, '', ret);
+		}
+	} catch (e) {
+		logger.error('[interfaceAddCase]:', e, ctx);
+		ctx.makeErrResObj();
+	}
+}
+
+
+InfTestController.deleteTestCase = async (ctx) => {
+	try {
+		let { case_id } = ctx.paramsObj;
+		ctx.makeResObj(200, '', await InfTestService.deleteTestCase(case_id));
+	} catch (e) {
+		logger.error('[deleteTarsFile]:', e, ctx);
+		ctx.makeErrResObj();
+	}
+}
+
+InfTestController.modifyTestCase = async (ctx) => {
+	try {
+		const { case_id, test_case_name, params, prior_set } = ctx.paramsObj;
+		ctx.makeResObj(200, '', await InfTestService.modifyTestCase(case_id, test_case_name, params, ctx.uid));
+	} catch (e) {
+		logger.error('[modifyTestCase]:', e, ctx);
+		ctx.makeErrResObj();
+	}
+}
+
+
 module.exports = InfTestController;

--- a/app/index.js
+++ b/app/index.js
@@ -417,6 +417,11 @@ if (WebConf.enable) {
 		['post', '/test_bencmark', InfTestController.testBencmark, {servant: 'notEmpty', fn: 'notEmpty'}],
 		['get', '/get_endpoints', InfTestController.getEndpoints, {servant: 'notEmpty'}],
 		['get', '/is_benchmark_installed', InfTestController.isBenchmarkInstalled],
+		// 测试用例
+		['post', '/interface_add_testcase', InfTestController.interfaceAddCase, { f_id: 'notEmpty', test_case_name: 'notEmpty', objName: 'notEmpty', file_name: 'notEmpty', module_name: 'notEmpty', interface_name: 'notEmpty', function_name: 'notEmpty', params: 'notEmpty' }],
+		['get', '/get_testcase_list', InfTestController.getTestCaseList, { f_id: 'notEmpty' }],
+		['get', '/delete_test_case', InfTestController.deleteTestCase, { case_id: 'notEmpty' }],
+		['post', '/modify_test_case', InfTestController.modifyTestCase, { case_id: 'notEmpty', test_case_name: 'notEmpty', params: 'notEmpty' }],
 
 		//taflogview
 		['get', '/logview_list', LogviewController.getLogFileList, {application: 'notEmpty', server_name: 'notEmpty', node_name: 'notEmpty'}],

--- a/app/service/infTest/InfTestService.js
+++ b/app/service/infTest/InfTestService.js
@@ -20,6 +20,7 @@ const { benchmarkPrx, benchmarkStruct} = require('../../../rpc');
 const {BenchmarkRunner} = require("./BenchmarkRunner");
 const InfTestDao = require('../../dao/InfTestDao');
 const webConf = require('../../../config/webConf');
+const TestCaseDao = require('../../dao/TestCaseDao');
 
 const fs = require('fs-extra');
 
@@ -371,6 +372,63 @@ InfTestService.stopBencmark = async(runParams)=>{
 }
 InfTestService.testBencmark = async(runParams)=>{
 	return await new BenchmarkRunner(runParams).test()
+}
+
+
+
+/**
+ * @name getTarsFile 获取解析后的tars文件记录
+ * @param {Object} params 
+ * @param {Array} fields
+ * @returns {Object} 插入的记录 
+ */
+InfTestService.getTestCase = async (params, fields) => {
+	return await TestCaseDao.getTestCase(params, fields);
+}
+
+
+/**
+ * @name addTestCase 将测试用例插入数据库
+ * @param {Object} params 
+ * @returns {Object} 插入的记录
+ */
+InfTestService.addTestCase = async (params) => {
+	await TestCaseDao.addTestCase(params);
+	delete params.context;
+	delete params.posttime;
+	return (await InfTestService.getTestCase(params, ['case_id', 'f_id', 'test_case_name', 'server_name', 'file_name', 'posttime', 'context', 'object_name', 'module_name', 'interface_name', 'function_name', 'posttime', 'modify_user']))[0];
+}
+
+
+/**
+ * @name getTestCaseList 获取测试用例列表
+ * @param {String} params 匹配字段
+ * @param {String} curPage 当前页
+ * @param {String} pageSize 每页数据条数
+ * @returns {Object} 测试用例列表
+ */
+InfTestService.getTestCaseList = async (params, curPage, pageSize) => {
+	return await TestCaseDao.getTestCaseList(params, curPage, pageSize);
+}
+
+
+/**
+ * @name deleteTestCase 从DB删除对应测试用例
+ * @param {String} case_id 用例ID
+ * @returns {Number} 删除的记录数
+ */
+InfTestService.deleteTestCase = async (case_id) => {
+	return await TestCaseDao.deleteTestCase(case_id);
+}
+
+/**
+ * @name modifyTestCase 修改对应测试用例
+ * @param {String} case_id 用例ID
+ * @param {String} test_case_name 用例名字
+ * @param {String} params 用例参数
+ */
+InfTestService.modifyTestCase = async (case_id, test_case_name, params, modify_user) => {
+	return await TestCaseDao.modifyTestCase(case_id, test_case_name, params, modify_user);
 }
 
 module.exports = InfTestService;

--- a/index/json/cn.json
+++ b/index/json/cn.json
@@ -565,7 +565,10 @@
         "network": "宿主资源",
         "disk": "磁盘管理",
         "nodeSelect": "节点筛选",
-        "copyNode": "副本伸缩"
+        "copyNode": "副本伸缩",
+
+        "addTestCase": "新增测试用例",
+        "testCaseList": "用例列表"
     },
     "index": {
         "rightView": {
@@ -1471,7 +1474,8 @@
         },
         "title": {
             "listTitle": "协议文件列表",
-            "dlgTitle": "上传协议文件"
+            "dlgTitle": "上传协议文件",
+            "testCaseList": "测试用例列表"
         },
         "dlg": {
             "selectLabel": "模块/接口/方法",
@@ -1479,7 +1483,10 @@
             "outParam": "方法出参",
             "tarsFile": "协议文件",
             "deleteMsg": "您确定要删除吗？",
-            "objName": "Servant名"
+            "objName": "Servant名",
+            "testCastName": "用例名称",
+            "fileName": "文件名"
+
         },
         "benchmark": {
             "inParam": "入参结构",

--- a/index/json/en.json
+++ b/index/json/en.json
@@ -546,7 +546,10 @@
         "network": "Network mapping",
         "disk": "Disk management",
         "nodeSelect": "Node selection",
-        "copyNode": "copy of the slip"
+        "copyNode": "copy of the slip",
+
+        "addTestCase": "add testcase",
+        "testCaseList": "testcase list"
     },
     "index": {
         "rightView": {
@@ -1464,7 +1467,9 @@
             "outParam": "out params",
             "tarsFile": "tars file",
             "deleteMsg": "are you sure to delete this file?",
-            "objName": "Servant Name"
+            "objName": "Servant Name",
+            "testCastName": "testcase name",
+            "fileName": "file name"
         },
         "benchmark": {
             "inParam": "in params struct",

--- a/sql/db_tars_web.sql
+++ b/sql/db_tars_web.sql
@@ -117,3 +117,23 @@ CREATE TABLE `t_gateway_obj` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2020-06-20 17:02:14
+
+
+DROP TABLE IF EXISTS `t_tars_test_case`;
+CREATE TABLE `t_tars_test_case` (
+  `case_id` int(11) NOT NULL AUTO_INCREMENT,
+  `f_id` int(11) NOT NULL COMMENT '所属的t_tars_files记录的id',
+  `test_case_name` varchar(128) NOT NULL DEFAULT '' COMMENT '测试用例名',
+  `application` varchar(64) NOT NULL DEFAULT '' COMMENT '应用名',
+  `server_name` varchar(128) NOT NULL DEFAULT '' COMMENT '服务名',
+  `object_name` varchar(256) NOT NULL DEFAULT '',
+  `file_name` varchar(64) NOT NULL DEFAULT '' COMMENT 'tars文件名',
+  `module_name` varchar(256) NOT NULL DEFAULT '',
+  `interface_name` varchar(256) NOT NULL DEFAULT '',
+  `function_name` varchar(256) NOT NULL DEFAULT '',
+  `posttime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `context` mediumtext COMMENT '用例内容',
+  `modify_user` varchar(64) NOT NULL DEFAULT '' COMMENT '用户',
+  PRIMARY KEY (`f_id`,`test_case_name`),
+  UNIQUE KEY `case_id` (`case_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=gbk COMMENT='接口测试 测试用例表';


### PR DESCRIPTION
本次pr为接口测试增加了测试用例管理功能，便于管理接口测试用例；
1、用例列表；
![image](https://user-images.githubusercontent.com/89832440/143206864-30c12166-545b-4e7f-8bf8-1fa8c6710eb6.png)
2、新增用例；
![image](https://user-images.githubusercontent.com/89832440/143207499-0507062b-54f9-49c9-86ec-a0cf7fd5a593.png)

![image](https://user-images.githubusercontent.com/89832440/143207052-99deab0c-6ccb-415c-8ab5-7fbfe9829bc1.png)
3、修改用例；
![image](https://user-images.githubusercontent.com/89832440/143207612-a9c30a27-d45c-4556-8ce6-e3c9c88d84e6.png)
![image](https://user-images.githubusercontent.com/89832440/143207140-84ea7cd5-b6e3-4bde-88fa-309447d91f4b.png)
4、删除用例；
![image](https://user-images.githubusercontent.com/89832440/143207435-58d9c884-a6db-41e4-97a3-c549b0809f99.png)
5、指定服务节点测试，便于在服务有多个节点的时候，指定测试几点（避免不知道请求到了哪个节点）
![image](https://user-images.githubusercontent.com/89832440/143208118-e487cdd6-d82d-4bf1-aef3-09d91e35c387.png)


