### PR TITLE
add test case managent

### DIFF
--- a/app/dao/TestCaseDao.js
+++ b/app/dao/TestCaseDao.js
@@ -1,0 +1,83 @@
+/**
+ * Tencent is pleased to support the open source community by making Tars available.
+ *
+ * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except 
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * specific language governing permissions and limitations under the License.
+ */
+
+const { tTarsTestCase } = require('./db').db_tars_web;
+
+module.exports = {
+    addTestCase: async (params) => {
+        return tTarsTestCase.upsert(params, {
+            fields: ['f_id', 'test_case_name', 'server_name', 'file_name', 'posttime', 'context', 'object_name', 'module_name', 'interface_name', 'function_name','modify_user']
+        })
+    },
+
+    getTestCase: async (params, fields) => {
+        let opt = {
+            raw: true,
+            where: params
+        };
+        if (fields) {
+            Object.assign(opt, { attributes: fields });
+        }
+        return tTarsTestCase.findAll(opt);
+    },
+
+    getContext: async (id) => {
+        return tTarsTestCase.findOne({
+            raw: true,
+            where: {
+                case_id: id
+            },
+            attributes: ['context']
+        })
+    },
+
+    deleteTestCase: async (id) => {
+        return tTarsTestCase.destroy({
+            where: {
+                case_id: id
+            }
+        });
+    },
+    deleteTestCaseByFid: async (f_id) => {
+        return tTarsTestCase.destroy({
+            where: {
+                f_id: f_id
+            }
+        });
+    },
+
+    getTestCaseList: async (params, curPage, pageSize) => {
+        let options = {
+            raw: true,
+            where: params,
+            order: [['posttime', 'DESC']]
+        };
+        if (curPage && pageSize) {
+            options.limit = pageSize;
+            options.offset = pageSize * (curPage - 1);
+        }
+        return await tTarsTestCase.findAndCountAll(options);
+    },
+    modifyTestCase: async (case_id, test_case_name, params, modify_user) => {
+        let updateOptions = {
+            test_case_name: test_case_name,
+            context: params,
+            modify_user: modify_user
+        };
+       
+        return await tTarsTestCase.update(updateOptions, { where: { case_id: case_id } });
+    }
+};

--- a/app/dao/db/db_tars_web_models/t_tars_test_case.js
+++ b/app/dao/db/db_tars_web_models/t_tars_test_case.js
@@ -1,0 +1,90 @@
+/**
+ * Tencent is pleased to support the open source community by making Tars available.
+ *
+ * Copyright (C) 2016THL A29 Limited, a Tencent company. All rights reserved.
+ *
+ * Licensed under the BSD 3-Clause License (the "License"); you may not use this file except 
+ * in compliance with the License. You may obtain a copy of the License at
+ *
+ * https://opensource.org/licenses/BSD-3-Clause
+ *
+ * Unless required by applicable law or agreed to in writing, software distributed 
+ * under the License is distributed on an "AS IS" BASIS, WITHOUT WARRANTIES OR 
+ * CONDITIONS OF ANY KIND, either express or implied. See the License for the 
+ * specific language governing permissions and limitations under the License.
+ */
+/* jshint indent: 1 */
+
+module.exports = function (sequelize, DataTypes) {
+	return sequelize.define('t_tars_test_case', {
+		case_id: {
+			type: DataTypes.INTEGER(11),
+			allowNull: false,
+			autoIncrement: true,
+			unique: true
+		},
+		f_id: {
+			type: DataTypes.INTEGER(11),
+			allowNull: false,
+			primaryKey: true
+		},
+		test_case_name: {
+			type: DataTypes.STRING(128),
+			allowNull: false,
+			defaultValue: '',
+			primaryKey: true
+		},
+		application: {
+			type: DataTypes.STRING(64),
+			allowNull: false,
+			defaultValue: '',
+		},
+		server_name: {
+			type: DataTypes.STRING(128),
+			allowNull: false,
+			defaultValue: '',
+		},
+		file_name: {
+			type: DataTypes.STRING(64),
+			allowNull: false,
+			defaultValue: '',
+		},
+		object_name: {
+			type: DataTypes.STRING(256),
+			allowNull: false,
+			defaultValue: '',
+		},
+		module_name: {
+			type: DataTypes.STRING(256),
+			allowNull: false,
+			defaultValue: '',
+		},
+		interface_name: {
+			type: DataTypes.STRING(256),
+			allowNull: false,
+			defaultValue: '',
+		},
+		function_name: {
+			type: DataTypes.STRING(256),
+			allowNull: false,
+			defaultValue: '',
+		},
+		posttime: {
+			type: DataTypes.DATE,
+			allowNull: false,
+			defaultValue: sequelize.literal('CURRENT_TIMESTAMP')
+		},
+		context: {
+			type: DataTypes.TEXT,
+			allowNull: true
+		},
+		modify_user: {
+			type: DataTypes.STRING(64),
+			allowNull: false,
+			defaultValue: '',
+		}
+	}, {
+		tableName: 't_tars_test_case',
+		timestamps: false
+	});
+};

--- a/app/index.js
+++ b/app/index.js
@@ -417,7 +417,11 @@ if (WebConf.enable) {
 		['post', '/test_bencmark', InfTestController.testBencmark, {servant: 'notEmpty', fn: 'notEmpty'}],
 		['get', '/get_endpoints', InfTestController.getEndpoints, {servant: 'notEmpty'}],
 		['get', '/is_benchmark_installed', InfTestController.isBenchmarkInstalled],
-
+		// 测试用例
+		['post', '/interface_add_testcase', InfTestController.interfaceAddCase, { f_id: 'notEmpty', test_case_name: 'notEmpty', objName: 'notEmpty', file_name: 'notEmpty', module_name: 'notEmpty', interface_name: 'notEmpty', function_name: 'notEmpty', params: 'notEmpty' }],
+		['get', '/get_testcase_list', InfTestController.getTestCaseList, { f_id: 'notEmpty' }],
+		['get', '/delete_test_case', InfTestController.deleteTestCase, { case_id: 'notEmpty' }],
+		['post', '/modify_test_case', InfTestController.modifyTestCase, { case_id: 'notEmpty', test_case_name: 'notEmpty', params: 'notEmpty' }],
 		//taflogview
 		['get', '/logview_list', LogviewController.getLogFileList, {application: 'notEmpty', server_name: 'notEmpty', node_name: 'notEmpty'}],
 		['get', '/logview_data', LogviewController.getLogData, {

--- a/app/service/infTest/InfTestService.js
+++ b/app/service/infTest/InfTestService.js
@@ -20,6 +20,7 @@ const { benchmarkPrx, benchmarkStruct} = require('../../../rpc');
 const {BenchmarkRunner} = require("./BenchmarkRunner");
 const InfTestDao = require('../../dao/InfTestDao');
 const webConf = require('../../../config/webConf');
+const TestCaseDao = require('../../dao/TestCaseDao');
 
 const fs = require('fs-extra');
 
@@ -371,6 +372,63 @@ InfTestService.stopBencmark = async(runParams)=>{
 }
 InfTestService.testBencmark = async(runParams)=>{
 	return await new BenchmarkRunner(runParams).test()
+}
+
+
+
+/**
+ * @name getTestCase 获取测试用例
+ * @param {Object} params 
+ * @param {Array} fields
+ * @returns {Object} 测试用例 
+ */
+InfTestService.getTestCase = async (params, fields) => {
+	return await TestCaseDao.getTestCase(params, fields);
+}
+
+
+/**
+ * @name addTestCase 将测试用例插入数据库
+ * @param {Object} params 
+ * @returns {Object} 插入的记录
+ */
+InfTestService.addTestCase = async (params) => {
+	await TestCaseDao.addTestCase(params);
+	delete params.context;
+	delete params.posttime;
+	return (await InfTestService.getTestCase(params, ['case_id', 'f_id', 'test_case_name', 'server_name', 'file_name', 'posttime', 'context', 'object_name', 'module_name', 'interface_name', 'function_name', 'posttime', 'modify_user']))[0];
+}
+
+
+/**
+ * @name getTestCaseList 获取测试用例列表
+ * @param {String} params 匹配字段
+ * @param {String} curPage 当前页
+ * @param {String} pageSize 每页数据条数
+ * @returns {Object} 测试用例列表
+ */
+InfTestService.getTestCaseList = async (params, curPage, pageSize) => {
+	return await TestCaseDao.getTestCaseList(params, curPage, pageSize);
+}
+
+
+/**
+ * @name deleteTestCase 从DB删除对应测试用例
+ * @param {String} case_id 用例ID
+ * @returns {Number} 删除的记录数
+ */
+InfTestService.deleteTestCase = async (case_id) => {
+	return await TestCaseDao.deleteTestCase(case_id);
+}
+
+/**
+ * @name modifyTestCase 修改对应测试用例
+ * @param {String} case_id 用例ID
+ * @param {String} test_case_name 用例名字
+ * @param {String} params 用例参数
+ */
+InfTestService.modifyTestCase = async (case_id, test_case_name, params, modify_user) => {
+	return await TestCaseDao.modifyTestCase(case_id, test_case_name, params, modify_user);
 }
 
 module.exports = InfTestService;

--- a/client/src/common/interface-debuger.vue
+++ b/client/src/common/interface-debuger.vue
@@ -1,7 +1,7 @@
 <template>
     <div class="page_server_debuger">
         <!-- tars文件列表 -->
-        <wrapper v-if="!showDebug && !showBm" ref="tarsFileListLoading">
+        <wrapper v-if="!showDebug && !showBm && !addTestCase && !showCaseList && !modifyTestCase" ref="tarsFileListLoading">
         <let-button size="small" theme="primary" class="add-btn" @click="openTarsUploadFileModal">{{$t('operate.add')}}</let-button>
 
         <let-table :data="tarsFileList" :title="$t('inf.title.listTitle')" :empty-msg="$t('common.nodata')">
@@ -13,7 +13,9 @@
             <template slot-scope="scope">
                 <let-table-operation @click="showDebuger(scope.row)">{{$t('inf.list.debug')}}</let-table-operation>  
                 <let-table-operation @click="showBenchmark(scope.row)">{{$t('inf.list.benchmark')}}</let-table-operation>  
+                <let-table-operation @click="getTestCaseList(scope.row)">{{$t('operate.testCaseList')}}</let-table-operation>
                 <let-table-operation @click="deleteTarsFile(scope.row.f_id)">{{$t('operate.delete')}}</let-table-operation>
+                <!-- <let-table-operation @click="gotoAddTestCase(scope.row)">{{$t('operate.addTestCase')}}</let-table-operation> -->
             </template>
             </let-table-column>
         </let-table>
@@ -90,6 +92,187 @@
                 -->
             </div>
         </let-modal>
+    
+
+
+        
+        <div v-if="addTestCase && !showCaseList">
+            <let-form class="left_align" itemWidth="530px">
+                <let-form-item :label="$t('inf.dlg.selectLabel')">
+                <let-cascader :data="contextData" required size="small" @change="getParams"></let-cascader>
+                </let-form-item>
+                <let-form-item :label="$t('inf.dlg.objName')" v-if="objList.length">
+                <let-select v-model="objName">
+                    <let-option v-for="item in objList" :value="item.servant" :key="item.servant"></let-option>
+                </let-select>
+                </let-form-item>
+            </let-form>
+
+            <!-- 用例名字 -->
+            <let-form class="left_align">
+                <let-form-item :label="$t('inf.dlg.testCastName')">
+                <let-input
+                    type="textarea"
+                    :rows="1"
+                    v-model="testCastName"
+                    :placeholder="$t('inf.dlg.testCastName')"
+                ></let-input>
+                </let-form-item>
+            </let-form>
+
+            <!-- 入参输入框 -->
+            <let-row>
+                <div class="params_container">
+                <let-col itemWidth="100%">
+                    <let-form itemWidth="100%">
+                    <let-input
+                        type="textarea"
+                        :rows="20"
+                        class="param_area div_line"
+                        v-model="inParam"
+                        :placeholder="$t('inf.dlg.inParam')"
+                    ></let-input>
+                    </let-form>
+                </let-col>
+                </div>
+            </let-row>
+
+            <div class="mt10">
+                <let-button theme="primary" @click="doAddTestCast">{{$t('operate.add')}}</let-button>
+                &nbsp;&nbsp;
+                <let-button theme="primary"  @click="addTestCase=false;showCaseList=true;">{{$t('operate.goback')}}</let-button>
+            </div>
+        </div>
+
+        
+        <!-- 测试用例 -->
+        <div v-if="showCaseList && !addTestCase">
+            <let-form class="left_align" itemWidth="530px">
+                <let-form-item :label="$t('inf.dlg.selectLabel')">
+                <let-cascader :data="contextData" required size="small" @change="getTestCaseByParams"></let-cascader>
+                </let-form-item>
+                <let-form-item :label="$t('inf.dlg.objName')" v-if="objList.length">
+                <let-select v-model="objName">
+                    <let-option v-for="item in objList" :value="item.servant" :key="item.servant"></let-option>
+                </let-select>
+                </let-form-item>
+            </let-form>
+
+            <let-table :data="testCaseList" :title="$t('operate.testCaseList')" :empty-msg="$t('common.nodata')">
+                <let-table-column :title="$t('inf.dlg.testCastName')" prop="test_case_name" width="100px"></let-table-column>
+                <let-table-column :title="$t('inf.dlg.objName')" prop="object_name" width="100px"></let-table-column>
+                <let-table-column :title="$t('inf.dlg.fileName')" prop="file_name" width="100px"></let-table-column>
+                <let-table-column :title="$t('module.title')" prop="module_name" width="100px"></let-table-column>
+                <let-table-column :title="$t('callChain.method')" prop="function_name" width="100px"></let-table-column>
+                <let-table-column :title="$t('nodes.user')" prop="modify_user" width="100px"></let-table-column>
+                <let-table-column :title="$t('board.alarm.table.content')" width="460px">
+                <template slot-scope="scope">
+                    <font color="red">{{scope.row.context}}</font>
+                </template>
+                </let-table-column>
+                <let-table-column :title="$t('operate.operates')" width="100px">
+                <template slot-scope="scope">
+                    <let-table-operation @click="gotoModify(scope.row)">{{$t('operate.modify')}}</let-table-operation>
+                    <let-table-operation @click="deleteTestCase(scope.row.case_id)">{{$t('operate.delete')}}</let-table-operation>
+                </template>
+                </let-table-column>
+
+                <let-table-column :title="$t('serverList.table.th.ip')" width="100px">
+                <template slot-scope="scope">
+                    <div v-for="item in totalServerList" :key="item" :value="item">
+                    <let-table-operation @click="doNodedebug(item,scope.row)">{{ item.node_name }}</let-table-operation>
+                    <br>
+                    </div>
+                </template>
+                </let-table-column>
+            </let-table>
+            <let-pagination
+                :page="pageNum"
+                @change="gotoPage"
+                style="margin-bottom: 32px;"
+                :total="total"
+            ></let-pagination>
+            <div class="mt10">
+                <let-button theme="primary" size="small" @click="gotoAddTestCase()">{{$t('operate.addTestCase')}}</let-button>
+                &nbsp;&nbsp;
+                <let-button theme="primary" size="small" @click="showCaseList=false">{{$t('operate.goback')}}</let-button>
+            </div>
+        </div>
+
+        <div v-if="modifyTestCase">
+            <let-form class="left_align" itemWidth="530px">
+                <let-form-item>
+                <span class="text-blue">{{modifyCaseItem.object_name}}</span>
+                </let-form-item>
+                <let-form-item>
+                <span class="text-blue">{{modifyCaseItem.module_name}}</span>
+                <span class="text-blue">{{modifyCaseItem.interface_name}}</span>
+                <span class="text-blue">{{modifyCaseItem.function_name}}</span>
+                </let-form-item>
+            </let-form>
+
+            <!-- 用例名字 -->
+            <let-form class="left_align">
+                <let-form-item :label="$t('inf.dlg.testCastName')">
+                <let-input
+                    type="textarea"
+                    :rows="1"
+                    v-model="testCastName"
+                    :placeholder="$t('inf.dlg.testCastName')"
+                ></let-input>
+                </let-form-item>
+            </let-form>
+
+            <!-- 入参输入框 -->
+            <let-row>
+                <div class="params_container">
+                <let-col itemWidth="100%">
+                    <let-form itemWidth="100%">
+                    <let-input
+                        type="textarea"
+                        :rows="20"
+                        class="param_area div_line"
+                        v-model="inParam"
+                        :placeholder="$t('inf.dlg.inParam')"
+                    ></let-input>
+                    </let-form>
+                </let-col>
+                </div>
+            </let-row>
+
+            <div class="mt10">
+            <let-button theme="primary" @click="doModifyTestCase">{{$t('operate.modify')}}</let-button>
+            &nbsp;&nbsp;
+            <let-button theme="primary" @click="modifyTestCase=false;showCaseList=true;">{{$t('operate.goback')}}</let-button>
+            </div>
+        </div>
+
+
+        <!--测试用例运行结果弹出框 -->
+        <let-modal
+        v-model="debugModal.show"
+        :title="$t('dcache.debug.debugResult')"
+        width="600px"
+        :footShow="false"
+        @close="closeDebugModal">
+
+        <!-- 入参输入框 -->
+        <let-row>
+            <div class="params_container">
+            <let-col itemWidth="100%">
+                <let-form itemWidth="100%">
+                <let-input
+                    type="textarea"
+                    :rows="40"
+                    class="param_area div_line"
+                    v-model="debugModal.resultParam"
+                    :placeholder="$t('dcache.debug.debugResult')"
+                ></let-input>
+                </let-form>
+            </let-col>
+            </div>
+        </let-row>
+        </let-modal>
     </div>
 </template>
 
@@ -114,12 +297,19 @@ export default {
                 set_group: '',
             },
             tarsFileList : [],
+            totalServerList: [],
 
             uploadModal : {
                 show : false,
                 model : {},
                 fileList2Show: [],
             },
+
+            debugModal: {
+                show: false,
+                resultParam: ""
+            },
+
             showDebug : false,
             showBm: false,
             showInstallBm:false,
@@ -133,9 +323,20 @@ export default {
             selectedMethods: [],
             objName : '',
             objList : [],
-            selectedId : ''
+            selectedId : '',
+            testCastName: "",
+            testCaseList: [],
+            showCaseList: false,
+            pageNum: 1,
+            pageSize: 20,
+            total: 1,
+            addTestCase: false,
+            modifyTestCase: false,
+            modifyCaseItem: {},
+            rowData : {}
         }
     },
+    props: ['treeid'],
     methods: {
         getFileList() {
             const loading = this.$Loading.show();
@@ -350,6 +551,193 @@ export default {
                 loading.hide();
                 this.$tip.error(`${this.$t('common.error')}: ${err.message || err.err_msg}`);
             });
+        },
+        // 删除测试用例
+        deleteTestCase(case_id) {
+            this.$confirm(this.$t("inf.dlg.deleteMsg"), this.$t("common.alert")).then(() => {
+                const loading = this.$Loading.show();
+                this.$ajax.getJSON("/server/api/delete_test_case", {
+                        case_id: case_id
+                    }).then(data => {
+                        loading.hide();
+                        this.getTestCaseListInner(this.pageNum);
+                    }).catch(err => {
+                        loading.hide();
+                        this.$tip.error(
+                            `${this.$t("common.error")}: ${err.message || err.err_msg}`
+                        );
+                    });
+            }).catch(() => {});
+        },
+        // 新增测试用例
+        gotoAddTestCase() {
+            this.addTestCase = true;
+            this.showCaseList = false;
+            this.selectedFileName = this.rowData.file_name;
+            this.inParam = '';
+            this.outParam = '';
+            this.selectedId = this.rowData.f_id;
+            this.objName = '';
+            this.testCastName = '';
+            this.selectedMethods = [];
+            this.getContextData(this.rowData.f_id);
+            this.getObjList();
+        },    
+        // 获取文件对应测试用例列表
+        getTestCaseListInner(curr_page) {
+            const loading = this.$Loading.show();
+            this.showCaseList = true;
+            this.$ajax.getJSON("/server/api/get_testcase_list", {
+                f_id: this.selectedId,
+                application: this.serverData.application,
+                server_name: this.serverData.server_name,
+                page_size: this.pageSize,
+                curr_page: curr_page
+            }).then(data => {
+                loading.hide();
+                this.pageNum = curr_page;
+                this.total = Math.ceil(data.count / this.pageSize);
+                this.testCaseList = data.rows;
+            }).catch(err => {
+                loading.hide();
+                this.$tip.error(
+                    `${this.$t("get_testcase_list.failed")}: ${err.err_msg ||
+                    err.message}`
+                );
+            });
+        },
+        // 切换服务实时状态页码
+        gotoPage(num) {
+            this.getTestCaseListInner(num);
+        },
+        getTestCaseList(row) {
+            this.rowData = row;
+            this.showCaseList = true;
+            this.testCaseList = [];
+            this.selectedFileName = row.file_name;
+            this.inParam = null;
+            this.outParam = null;
+            this.selectedId = row.f_id;
+            this.objName = null;
+            this.priorSet = null;
+            this.selectedMethods = [];
+            this.getContextData(row.f_id);
+            this.getObjList();
+            this.getTestCaseListInner(1);
+        },
+        getTestCaseByParams(value) {
+            this.selectedMethods = value;
+            if (value.length == 3) {
+                this.getTestCaseListInner(1);
+            }
+        },
+        doAddTestCast() {
+            const loading = this.$Loading.show();
+            this.$ajax
+                .postJSON("/server/api/interface_add_testcase", {
+                    f_id: this.selectedId,
+                    application: this.serverData.application,
+                    server_name: this.serverData.server_name,
+                    file_name: this.selectedFileName,
+                    module_name: this.selectedMethods[0],
+                    interface_name: this.selectedMethods[1],
+                    function_name: this.selectedMethods[2],
+                    params: this.inParam,
+                    test_case_name: this.testCastName,
+                    objName: this.objName
+                }).then(data => {
+                    loading.hide();
+                    this.addTestCase = false;
+                    this.getTestCaseListInner(this.pageNum);
+                }).catch(err => {
+                    loading.hide();
+                    this.$tip.error(
+                        `${this.$t("common.error")}: ${err.message || err.err_msg}`
+                    );
+                });
+        },
+        getServerList() {
+            // 获取服务列表
+            const loading = this.$Loading.show();
+            this.$ajax.getJSON("/server/api/server_list", {
+                tree_node_id: this.treeid
+            }).then(data => {
+                loading.hide();
+                const items = data || [];
+                items.forEach(item => {
+                    item.isChecked = false;
+                });
+                this.totalServerList = items;
+            }).catch(err => {
+                loading.hide();
+                this.$confirm(
+                    err.err_msg || err.message || this.$t("serverList.table.msg.fail")
+                ).then(() => {
+                    this.getServerList();
+                });
+            });
+        },
+        gotoModify(row) {
+            this.modifyCaseItem = row;
+            this.modifyTestCase = true;
+            this.showCaseList = false;
+            this.inParam = row.context;
+            this.testCastName = row.test_case_name;
+        },
+        doModifyTestCase() {
+            const loading = this.$Loading.show();
+            this.$ajax.postJSON("/server/api/modify_test_case", {
+                case_id: this.modifyCaseItem.case_id,
+                params: this.inParam,
+                test_case_name: this.testCastName,
+            }).then(data => {
+                loading.hide();
+                this.modifyTestCase = false;
+                this.getTestCaseListInner(this.pageNum);
+            }).catch(err => {
+                loading.hide();
+                this.$tip.error(
+                    `${this.$t("common.error")}: ${err.message || err.err_msg}`
+                );
+            });
+        },
+        doNodedebug(server, row) {
+            const loading = this.$Loading.show();
+            this.$ajax.getJSON("/server/api/adapter_conf_list", {
+                id: server.id
+            }).then(adapterData => {
+                // node到endpoint的映射
+                var obj_endpoint = {};
+                for (let tmp_data of adapterData) 
+                {
+                    obj_endpoint[tmp_data.servant]=tmp_data.endpoint;
+                }
+                //去到adapter信息  向特定节点请求服务
+                this.$ajax.postJSON("/server/api/interface_test", {
+                        id: this.selectedId,
+                        application: this.serverData.application,
+                        server_name: this.serverData.server_name,
+                        file_name: this.selectedFileName,
+                        module_name: row.module_name,
+                        interface_name: row.interface_name,
+                        function_name: row.function_name,
+                        params: row.context,
+                        objName: row.object_name + "@" + obj_endpoint[row.object_name]
+                    }).then(data => {
+                        loading.hide();
+                        this.debugModal.show = true;
+                        this.debugModal.resultParam = JSON.stringify(JSON.parse(data), null, 4);
+                    }).catch(err => {
+                        loading.hide();
+                        this.debugModal.show = true;
+                        this.debugModal.resultParam = err.message || err.err_msg;
+                    });
+            }).catch(err => {
+                loading.hide();
+                this.$tip.error(
+                    `${this.$t("serverList.restart.failed")}: ${err.err_msg || err.message}`
+                );
+            });
         }
     },
     created() {
@@ -359,6 +747,7 @@ export default {
     mounted() {
         this.getFileList();
         this.getBmInstalled();
+        this.getServerList();
     }
 }
 </script>

--- a/index/json/cn.json
+++ b/index/json/cn.json
@@ -566,7 +566,9 @@
         "disk": "磁盘管理",
         "nodeSelect": "节点筛选",
         "copyNode": "副本伸缩",
-        "viewEvent": "查看事件"
+        "viewEvent": "查看事件",
+        "addTestCase": "新增测试用例",
+        "testCaseList": "用例列表"
     },
     "index": {
         "rightView": {
@@ -1493,7 +1495,9 @@
             "outParam": "方法出参",
             "tarsFile": "协议文件",
             "deleteMsg": "您确定要删除吗？",
-            "objName": "Servant名"
+            "objName": "Servant名",
+            "testCastName": "用例名称",
+            "fileName": "文件名"
         },
         "benchmark": {
             "inParam": "入参结构",

--- a/index/json/en.json
+++ b/index/json/en.json
@@ -547,7 +547,9 @@
         "disk": "Disk management",
         "nodeSelect": "Node selection",
         "copyNode": "copy of the slip",
-        "viewEvent": "View events"
+        "viewEvent": "View events",
+        "addTestCase": "add testcase",
+        "testCaseList": "testcase list"
     },
     "index": {
         "rightView": {
@@ -1468,7 +1470,9 @@
             "outParam": "out params",
             "tarsFile": "tars file",
             "deleteMsg": "are you sure to delete this file?",
-            "objName": "Servant Name"
+            "objName": "Servant Name",
+            "testCastName": "testcase name",         
+            "fileName": "file name"
         },
         "benchmark": {
             "inParam": "in params struct",

--- a/sql/db_tars_web.sql
+++ b/sql/db_tars_web.sql
@@ -117,3 +117,22 @@ CREATE TABLE `t_gateway_obj` (
 /*!40111 SET SQL_NOTES=@OLD_SQL_NOTES */;
 
 -- Dump completed on 2020-06-20 17:02:14
+
+DROP TABLE IF EXISTS `t_tars_test_case`;
+CREATE TABLE `t_tars_test_case` (
+  `case_id` int(11) NOT NULL AUTO_INCREMENT,
+  `f_id` int(11) NOT NULL COMMENT '所属的t_tars_files记录的id',
+  `test_case_name` varchar(128) NOT NULL DEFAULT '' COMMENT '测试用例名',
+  `application` varchar(64) NOT NULL DEFAULT '' COMMENT '应用名',
+  `server_name` varchar(128) NOT NULL DEFAULT '' COMMENT '服务名',
+  `object_name` varchar(256) NOT NULL DEFAULT '',
+  `file_name` varchar(64) NOT NULL DEFAULT '' COMMENT 'tars文件名',
+  `module_name` varchar(256) NOT NULL DEFAULT '',
+  `interface_name` varchar(256) NOT NULL DEFAULT '',
+  `function_name` varchar(256) NOT NULL DEFAULT '',
+  `posttime` timestamp NOT NULL DEFAULT CURRENT_TIMESTAMP ON UPDATE CURRENT_TIMESTAMP,
+  `context` mediumtext COMMENT '用例内容',
+  `modify_user` varchar(64) NOT NULL DEFAULT '' COMMENT '用户',
+  PRIMARY KEY (`f_id`,`test_case_name`),
+  UNIQUE KEY `case_id` (`case_id`)
+) ENGINE=InnoDB DEFAULT CHARSET=gbk COMMENT='接口测试 测试用例表';


### PR DESCRIPTION
本次pr为接口测试增加了测试用例管理功能，便于管理接口测试用例；
1、用例列表；
![image](https://user-images.githubusercontent.com/89832440/143206864-30c12166-545b-4e7f-8bf8-1fa8c6710eb6.png)
2、新增用例；
![image](https://user-images.githubusercontent.com/89832440/143207499-0507062b-54f9-49c9-86ec-a0cf7fd5a593.png)

![image](https://user-images.githubusercontent.com/89832440/143207052-99deab0c-6ccb-415c-8ab5-7fbfe9829bc1.png)
3、修改用例；
![image](https://user-images.githubusercontent.com/89832440/143207612-a9c30a27-d45c-4556-8ce6-e3c9c88d84e6.png)
![image](https://user-images.githubusercontent.com/89832440/143207140-84ea7cd5-b6e3-4bde-88fa-309447d91f4b.png)
4、删除用例；
![image](https://user-images.githubusercontent.com/89832440/143207435-58d9c884-a6db-41e4-97a3-c549b0809f99.png)
5、指定服务节点测试，便于在服务有多个节点的时候，指定测试几点（避免不知道请求到了哪个节点）
![image](https://user-images.githubusercontent.com/89832440/143208118-e487cdd6-d82d-4bf1-aef3-09d91e35c387.png)


