### PR TITLE
fix max key length is 767 bytes

### DIFF
--- a/sql/db_user_system.sql
+++ b/sql/db_user_system.sql
@@ -64,6 +64,8 @@ VALUES (1,'admin','',now());
 /*!40000 ALTER TABLE `t_user_info` ENABLE KEYS */;
 UNLOCK TABLES;
 
+/*!40101 set global innodb_large_prefix=1 */;
+/*!40101 set global innodb_file_format=BARRACUDA */;
 CREATE TABLE `t_token` (
   `id` int(11) unsigned NOT NULL AUTO_INCREMENT,
   `uid` varchar(128) DEFAULT NULL,
@@ -74,7 +76,7 @@ CREATE TABLE `t_token` (
   PRIMARY KEY (`id`),
   KEY `uid` (`uid`),
   KEY `token` (`token`)
-) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4;
+) ENGINE=InnoDB AUTO_INCREMENT=1 DEFAULT CHARSET=utf8mb4 row_format=dynamic;
 
 
 CREATE TABLE `t_setting` (


### PR DESCRIPTION
不好意思 https://github.com/TarsCloud/TarsWeb/pull/169 提交的唐突了，测试后发现，会报"fix max key length is 767 bytes"错误，后参考https://cloud.tencent.com/developer/article/1005696 修复，从新提交
![image](https://user-images.githubusercontent.com/88697234/150270855-6170cfd6-edbf-4963-b938-d924826f1505.png)
