### PR TITLE
fix: let host allow set more chars

### DIFF
--- a/app/dao/db/db_tars_models/t_config_files.js
+++ b/app/dao/db/db_tars_models/t_config_files.js
@@ -44,7 +44,7 @@ module.exports = function(sequelize, DataTypes) {
 			defaultValue: ''
 		},
 		host: {
-			type: DataTypes.STRING(256),
+			type: DataTypes.STRING(128),
 			allowNull: false,
 			defaultValue: ''
 		},

--- a/app/dao/db/db_tars_models/t_config_files.js
+++ b/app/dao/db/db_tars_models/t_config_files.js
@@ -44,7 +44,7 @@ module.exports = function(sequelize, DataTypes) {
 			defaultValue: ''
 		},
 		host: {
-			type: DataTypes.STRING(20),
+			type: DataTypes.STRING(256),
 			allowNull: false,
 			defaultValue: ''
 		},

--- a/app/dao/db/db_tars_models/t_task_item.js
+++ b/app/dao/db/db_tars_models/t_task_item.js
@@ -41,7 +41,7 @@ module.exports = function(sequelize, DataTypes) {
 			allowNull: true
 		},
 		node_name: {
-			type: DataTypes.STRING(20),
+			type: DataTypes.STRING(128),
 			allowNull: true
 		},
 		command: {


### PR DESCRIPTION
fix: https://github.com/TarsCloud/TarsWeb/issues/195

```
{"level":"error","message":"ConfigService.js:317|[insertConfigFile]: SequelizeDatabaseError: Data too long for column 'host' at row 1\n    at Query.formatError (/usr/local/tars/cpp/deploy/web/node_modules/sequelize/lib/dialects/mysql/query.js:244:16)\n    at Execute.handler [as onResult] (/usr/local/tars/cpp/deploy/web/node_modules/sequelize/lib/dialects/mysql/query.js:51:23)\n    at Execute.execute (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/commands/command.js:30:14)\n    at Connection.handlePacket (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/connection.js:408:32)\n    at PacketParser.onPacket (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/connection.js:70:12)\n    at PacketParser.executeStart (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/packet_parser.js:75:16)\n    at Socket.<anonymous> (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/connection.js:77:25)\n    at Socket.emit (node:events:390:28)\n    at addChunk (node:internal/streams/readable:315:12)\n    at readableAddChunk (node:internal/streams/readable:289:9)\n    at Socket.Readable.push (node:internal/streams/readable:228:10)\n    at TCP.onStreamRead (node:internal/stream_base_commons:199:23) ","timestamp":"2022-10-13 07:51:56.393"}
{"level":"error","message":"10.0.42.74|admin|ConfigController.js:214|[nodeConfigFileList] TypeError: Cannot read properties of undefined (reading 'get')\n    at Object.ConfigService.getNodeConfigFile (/usr/local/tars/cpp/deploy/web/app/service/config/ConfigService.js:318:20)\n    at async Object.ConfigController.nodeConfigFileList (/usr/local/tars/cpp/deploy/web/app/controller/config/ConfigController.js:203:15)\n    at async /usr/local/tars/cpp/deploy/web/midware/index.js:79:4\n    at async module.exports (/usr/local/tars/cpp/deploy/web/midware/noCacheMidware.js:24:2)\n    at async module.exports (/usr/local/tars/cpp/deploy/web/midware/authMidware.js:23:5)\n    at async /usr/local/tars/cpp/deploy/web/midware/paramsMidware.js:86:4\n    at async /usr/local/tars/cpp/deploy/web/midware/paramsMidware.js:45:3\n    at async /usr/local/tars/cpp/deploy/web/app.js:131:5\n    at async static (/usr/local/tars/cpp/deploy/web/node_modules/koa-static-router/index.js:76:9)\n    at async pathname (/usr/local/tars/cpp/deploy/web/midware/ssoMidware.js:60:13)\n    at async /usr/local/tars/cpp/deploy/web/app.js:102:5\n    at async module.exports (/usr/local/tars/cpp/deploy/web/midware/localeMidware.js:72:2)\n    at async session (/usr/local/tars/cpp/deploy/web/node_modules/koa-session/index.js:41:7)  ","timestamp":"2022-10-13 07:51:56.394"}
{"level":"error","message":"ConfigService.js:317|[insertConfigFile]: SequelizeDatabaseError: Data too long for column 'host' at row 1\n    at Query.formatError (/usr/local/tars/cpp/deploy/web/node_modules/sequelize/lib/dialects/mysql/query.js:244:16)\n    at Execute.handler [as onResult] (/usr/local/tars/cpp/deploy/web/node_modules/sequelize/lib/dialects/mysql/query.js:51:23)\n    at Execute.execute (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/commands/command.js:30:14)\n    at Connection.handlePacket (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/connection.js:408:32)\n    at PacketParser.onPacket (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/connection.js:70:12)\n    at PacketParser.executeStart (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/packet_parser.js:75:16)\n    at Socket.<anonymous> (/usr/local/tars/cpp/deploy/web/node_modules/mysql2/lib/connection.js:77:25)\n    at Socket.emit (node:events:390:28)\n    at addChunk (node:internal/streams/readable:315:12)\n    at readableAddChunk (node:internal/streams/readable:289:9)\n    at Socket.Readable.push (node:internal/streams/readable:228:10)\n    at TCP.onStreamRead (node:internal/stream_base_commons:199:23) ","timestamp":"2022-10-13 07:51:56.939"}
{"level":"error","message":"10.0.42.74|admin|ConfigController.js:214|[nodeConfigFileList] TypeError: Cannot read properties of undefined (reading 'get')\n    at Object.ConfigService.getNodeConfigFile (/usr/local/tars/cpp/deploy/web/app/service/config/ConfigService.js:318:20)\n    at async Object.ConfigController.nodeConfigFileList (/usr/local/tars/cpp/deploy/web/app/controller/config/ConfigController.js:203:15)\n    at async /usr/local/tars/cpp/deploy/web/midware/index.js:79:4\n    at async module.exports (/usr/local/tars/cpp/deploy/web/midware/noCacheMidware.js:24:2)\n    at async module.exports (/usr/local/tars/cpp/deploy/web/midware/authMidware.js:23:5)\n    at async /usr/local/tars/cpp/deploy/web/midware/paramsMidware.js:86:4\n    at async /usr/local/tars/cpp/deploy/web/midware/paramsMidware.js:45:3\n    at async /usr/local/tars/cpp/deploy/web/app.js:131:5\n    at async static (/usr/local/tars/cpp/deploy/web/node_modules/koa-static-router/index.js:76:9)\n    at async pathname (/usr/local/tars/cpp/deploy/web/midware/ssoMidware.js:60:13)\n    at async /usr/local/tars/cpp/deploy/web/app.js:102:5\n    at async module.exports (/usr/local/tars/cpp/deploy/web/midware/localeMidware.js:72:2)\n    at async session (/usr/local/tars/cpp/deploy/web/node_modules/koa-session/index.js:41:7)  ","timestamp":"2022-10-13 07:51:56.940"}
```